### PR TITLE
Support python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+__pycache__
 .ipynb_checkpoints

--- a/mdcs-api
+++ b/mdcs-api
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import argparse
 import getpass
 import mdcs
@@ -11,9 +11,11 @@ import xmltodict
 from io import BytesIO
 import codecs
 
-#-------------------------------------------------------------------------------
-# functions
-#-------------------------------------------------------------------------------
+'''
+-------------------------------------------------------------------------------
+functions
+-------------------------------------------------------------------------------
+'''
 
 # get command line input
 def get_function_args():
@@ -39,7 +41,7 @@ def get_function_args():
         help='[optional] Certificate file\n\n',
         metavar='<cert>')
     parser.add_argument(
-        '-curate', 
+        '-curate',
         action='store_true',
         dest='curate',
         help=
@@ -59,7 +61,7 @@ def get_function_args():
 
 ''')
     parser.add_argument(
-        '-explore', 
+        '-explore',
         action='store_true',
         dest='explore',
         help=
@@ -117,7 +119,7 @@ def get_function_args():
            
 ''')
     parser.add_argument(
-        '-smart-xsd', 
+        '-smart-xsd',
         action='store_true',
         dest='smart_xsd',
         help=
@@ -187,31 +189,31 @@ def get_function_args():
     # templates command line input
     if args['templates']:
         parser.add_argument(
-            '-add', 
+            '-add',
             action='store_true',
             dest='templates_add')
         parser.add_argument(
-            '-all', 
+            '-all',
             action='store_true',
             dest='templates_all')
         parser.add_argument(
-            '-download', 
+            '-download',
             action='store_true',
             dest='download_xsd')
         parser.add_argument(
-            '-current', 
+            '-current',
             action='store_true',
             dest='templates_current')
         parser.add_argument(
-            '-find', 
+            '-find',
             action='store_true',
             dest='templates_find')
         parser.add_argument(
-            '-delete', 
+            '-delete',
             action='store_true',
             dest='templates_delete')
         parser.add_argument(
-            '-restore', 
+            '-restore',
             action='store_true',
             dest='templates_restore')
         known_args, unknown_args = parser.parse_known_args()
@@ -363,6 +365,7 @@ def get_function_args():
     
     return args
 
+
 # write list of json results to disk
 def write_json_records(records):
     for item in records:
@@ -371,7 +374,7 @@ def write_json_records(records):
         content=item['content']
         content_root ,= content.keys()
         fname=content_title+"."+content_root+"."+content_id+".json"
-        print "Saving file:",fname
+        print("Saving file: {}".format(fname)),
         with codecs.open(fname, encoding='utf-8', mode='w+') as f:
             f.write("%s" % json.dumps(content,indent=4,separators=(',', ': ')))
 
@@ -383,39 +386,39 @@ def write_xml_records(records):
         content=item['content']
         content_root = content.split('\n')[1].split('>')[0].replace('<','')
         fname=content_title+"."+content_root+"."+content_id+".xml"
-        print "Saving file:",fname
+        print("Saving file: {}".format(fname))
         with codecs.open(fname, encoding='utf-8', mode='w+') as f:
             f.write(u'%s' % content)
 
 # write list of xml results to disk
 def print_xml_records(records):
-    print len(records)," records were found in the repository."
+    print("{} records were found in the repository.".format(len(records)))
     width = 25
     
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}|{3:25}"
-    print column.format("Title","Root Element","Record ID","Template ID")
+    print(column.format("Title","Root Element","Record ID","Template ID"))
     for r in records:
         title = r['title']
         if len(title) > width:
             title = title[0:(width-3)]+"..."
-        print column.format(title,r['content'].keys()[0],r['_id'],r['schema'])
+        print(column.format(title,list(r['content'].keys())[0],r['_id'],r['schema']))
 
 # write list of xsd results to disk
 def write_xsd_records(records):
     for item in records:
         fname=item['filename']
         content=item['content']
-        print "Saving file:",fname
+        print("Saving file: {}".format(fname))
         with codecs.open(fname, encoding='utf-8', mode='w+') as f:
             f.write(u'%s' % content)
 
 # print list of xsd results to screen
 def print_xsd_records(records):
-    print len(records)," schemas were found in the repository."
+    print("{} schemas were found in the repository.".format(len(records)))
     width = 55
     
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}"
-    print column.format("Title","Filename","Template ID")
+    print(column.format("Title","Filename","Template ID"))
     for r in records:
         title = r['title']
         if len(title) > width:
@@ -423,7 +426,7 @@ def print_xsd_records(records):
         filename = r['filename']
         if len(filename) > width:
             filename = filename[0:(width-3)]+"..."
-        print column.format(title,filename,r['id'])
+        print(column.format(title,filename,r['id']))
 
 # curate rest actions
 def curate(args):
@@ -439,10 +442,10 @@ def curate(args):
             args['pswd'],
             cert=args['cert'],
             template_title=args['template_name'])
-        print "Successful upload of:",xml
+        print("Successful upload of:{}".format(xml))
         
     else:
-        print "Performing automatic upload of multiple XML records"
+        print("Performing automatic upload of multiple XML records")
         for xml in args['xml_file']:
             record_name = xml.replace('.xml','')
             response = mdcs.curate_as(
@@ -454,24 +457,24 @@ def curate(args):
                 cert=args['cert'],
                 template_title=args['template_name'])
             
-            print "Successful upload of:",xml,"as",record_name
+            print("Successful upload of: {xml} as {record_name}")
 
 # blob rest actions
 def blob(args):
-    print mdcs.blob.upload(
+    print(mdcs.blob.upload(
         args['file'],
         args['host'],
         args['user'],
         args['pswd'],
-        cert=args['cert'])
+        cert=args['cert']))
 
 # explore rest actions
 def explore(args):
     if args['delete_record']:
         if any([args['template_name'],args['record_name'],args['download_json'],args['download_xml']]):
-            print "Option -explore -delete can only be used with -id"
+            print("Option -explore -delete can only be used with -id")
         elif not args['record_id']:
-            print "You must specifyt an id with -id"
+            print("You must specifyt an id with -id")
         else:
             response = mdcs.explore.delete(
                 args['record_id'],
@@ -479,7 +482,7 @@ def explore(args):
                 args['user'],
                 args['pswd'],
                 cert=args['cert'])
-            print "Successful deletion of:", args['record_id']
+            print("Successful deletion of: {}".format(args['record_id']))
     
     elif any([args['template_name'],args['record_name'],args['record_id']]):
         if not any([args['download_json'],args['download_xml']]):
@@ -557,9 +560,9 @@ def templates(args):
             cert=args['cert'],
             version=args['version'],
             dependencies=args['dependencies'])
-        print "Success:"
-        print "title:",response['title']
-        print "filename:",response['filename']
+        print("Success:")
+        print("title:"),response['title']
+        print("filename:"),response['filename']
     
     elif args['templates_all']:
         templates = mdcs.templates.select_all(
@@ -591,7 +594,7 @@ def templates(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print "I found",template_id
+        print("I found"),template_id
     
     elif args['templates_delete']:
         response = mdcs.templates.delete(
@@ -601,7 +604,7 @@ def templates(args):
             args['pswd'],
             cert=args['cert'],
             next=args['next'])
-        print response
+        print(response)
     
     elif args['templates_restore']:
         response = mdcs.templates.restore(
@@ -610,7 +613,7 @@ def templates(args):
             args['user'],
             args['pswd'],
             cert=args['cert'])
-        print response
+        print(response)
 
 # types rest actions
 def types(args):
@@ -624,9 +627,9 @@ def types(args):
             cert=args['cert'],
             version=args['version'],
             dependencies=args['dependencies'])
-        print "Success:"
-        print "title:",response['title']
-        print "filename:",response['filename']
+        print("Success:")
+        print("title: {}".format(response['title']))
+        print("filename: {}".format(response['filename']))
     
     elif args['types_all']:
         types = mdcs.types.select_all(
@@ -658,7 +661,7 @@ def types(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print "I found",type_id
+        print("I found"),type_id
     
     elif args['types_delete']:
         response = mdcs.types.delete(
@@ -668,7 +671,7 @@ def types(args):
             args['pswd'],
             cert=args['cert'],
             next=args['next'])
-        print response
+        print(response)
     
     elif args['types_restore']:
         response = mdcs.types.restore(
@@ -677,7 +680,7 @@ def types(args):
             args['user'],
             args['pswd'],
             cert=args['cert'])
-        print response
+        print(response)
 
 # xsd smart uploader functions
 def xsd_type_dependencies(xsd_name):
@@ -734,7 +737,7 @@ def recursive_upload_xsd(xsd_name):
             cert=args['cert'],
             title=name)
         if xsd_id is None:
-            print "uploading",name,"as",xsd_type
+            print("uploading {} as {}".format(name,xsd_type))
             response = mdcs.types.add(
                 xsd_name,
                 name,
@@ -750,7 +753,7 @@ def recursive_upload_xsd(xsd_name):
                 cert=args['cert'],
                 title=name)
         else:
-            print "found dependency",name,"as",xsd_id
+            print("found dependency {} as {}".format(name,xsd_id))
             
     else:
         xsd_id = mdcs.templates.current_id(
@@ -760,7 +763,7 @@ def recursive_upload_xsd(xsd_name):
             cert=args['cert'],
             title=name)
         if xsd_id is None:
-            print "uploading",name,"as",xsd_type
+            print("uploading {} as {}".format(name,xsd_type))
             response = mdcs.templates.add(
                 xsd_name,
                 name,
@@ -776,7 +779,7 @@ def recursive_upload_xsd(xsd_name):
                 cert=args['cert'],
                 title=name)
         else:
-            print "found Template",name,"as",xsd_id
+            print("found Template {} as {}".format(name,xsd_id))
     
     return xsd_id
 

--- a/mdcs-api
+++ b/mdcs-api
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 import argparse
 import getpass
 import mdcs

--- a/mdcs-api
+++ b/mdcs-api
@@ -52,7 +52,7 @@ def get_function_args():
 
 ''')
     parser.add_argument(
-        '-blob',
+        '-blob', 
         action='store_true',
         dest='blob',
         help=
@@ -75,7 +75,7 @@ def get_function_args():
 
 ''')
     parser.add_argument(
-        '-templates',
+        '-templates', 
         action='store_true',
         dest='templates',
         help=
@@ -94,10 +94,10 @@ def get_function_args():
            -next <ID of template to be promoted to current> [optional]
 -restore   Restore a deleted Template:
            -id <ID of template to restore>
-
+           
 ''')
     parser.add_argument(
-        '-types',
+        '-types', 
         action='store_true',
         dest='types',
         help=
@@ -116,7 +116,7 @@ def get_function_args():
            -next <ID of type to be promoted to current> [optional]
 -restore   Restore a deleted Type:
            -id <ID of type to restore>
-
+           
 ''')
     parser.add_argument(
         '-smart-xsd',
@@ -128,7 +128,7 @@ def get_function_args():
 ''')
     known_args, unknown_args = parser.parse_known_args()
     args = vars(known_args)
-
+    
     # curate command line input
     if args['curate']:
         parser.add_argument(
@@ -147,7 +147,7 @@ def get_function_args():
             dest='record_name',
             default=None,
             type=str)
-
+    
     # blob command line input
     if args['blob']:
         parser.add_argument(
@@ -155,7 +155,7 @@ def get_function_args():
             dest='file',
             type=str,
             required=True)
-
+    
     # explore command line input
     if args['explore']:
         parser.add_argument(
@@ -174,18 +174,18 @@ def get_function_args():
             type=str,
             default=None)
         parser.add_argument(
-            '-j',
+            '-j', 
             action='store_true',
             dest='download_json')
         parser.add_argument(
-            '-x',
+            '-x', 
             action='store_true',
             dest='download_xml')
         parser.add_argument(
-            '-delete',
+            '-delete', 
             action='store_true',
             dest='delete_record')
-
+    
     # templates command line input
     if args['templates']:
         parser.add_argument(
@@ -218,7 +218,7 @@ def get_function_args():
             dest='templates_restore')
         known_args, unknown_args = parser.parse_known_args()
         args = vars(known_args)
-
+        
         if args['templates_add']:
             parser.add_argument(
                 "-x",
@@ -240,14 +240,14 @@ def get_function_args():
                 dest='dependencies',
                 type=str,
                 default=None)
-
+        
         if args['templates_find']:
             parser.add_argument(
                 "-n",
                 dest='name',
                 type=str,
                 required=True)
-
+        
         if args['templates_delete']:
             parser.add_argument(
                 "-id",
@@ -259,47 +259,47 @@ def get_function_args():
                 dest='next',
                 type=str,
                 default=None)
-
+    
         if args['templates_restore']:
             parser.add_argument(
                 "-id",
                 dest='id',
                 type=str,
                 required=True)
-
+    
     # types command line input
     if args['types']:
         parser.add_argument(
-            '-add',
+            '-add', 
             action='store_true',
             dest='types_add')
         parser.add_argument(
-            '-all',
+            '-all', 
             action='store_true',
             dest='types_all')
         parser.add_argument(
-            '-download',
+            '-download', 
             action='store_true',
             dest='download_xsd')
         parser.add_argument(
-            '-current',
+            '-current', 
             action='store_true',
             dest='types_current')
         parser.add_argument(
-            '-find',
+            '-find', 
             action='store_true',
             dest='types_find')
         parser.add_argument(
-            '-delete',
+            '-delete', 
             action='store_true',
             dest='types_delete')
         parser.add_argument(
-            '-restore',
+            '-restore', 
             action='store_true',
             dest='types_restore')
         known_args, unknown_args = parser.parse_known_args()
         args = vars(known_args)
-
+        
         if args['types_add']:
             parser.add_argument(
                 "-x",
@@ -321,14 +321,14 @@ def get_function_args():
                 dest='dependencies',
                 type=str,
                 default=None)
-
+        
         if args['types_find']:
             parser.add_argument(
                 "-n",
                 dest='name',
                 type=str,
                 required=True)
-
+        
         if args['types_delete']:
             parser.add_argument(
                 "-id",
@@ -340,14 +340,14 @@ def get_function_args():
                 dest='next',
                 type=str,
                 default=None)
-
+        
         if args['types_restore']:
             parser.add_argument(
                 "-id",
                 dest='id',
                 type=str,
                 required=True)
-
+    
     # smart-xsd command line input
     if args['smart_xsd']:
         parser.add_argument(
@@ -355,14 +355,14 @@ def get_function_args():
             dest='template_name',
             type=str,
             default=None)
-
+    
     known_args, unknown_args = parser.parse_known_args()
     args = vars(known_args)
-
+    
     # get username and password
     if args['user'] is None: args['user'] = getpass.getuser()
     args['pswd'] = getpass.getpass()
-
+    
     return args
 
 
@@ -394,7 +394,7 @@ def write_xml_records(records):
 def print_xml_records(records):
     print("{} records were found in the repository.".format(len(records)))
     width = 25
-
+    
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}|{3:25}"
     print(column.format("Title","Root Element","Record ID","Template ID"))
     for r in records:
@@ -416,7 +416,7 @@ def write_xsd_records(records):
 def print_xsd_records(records):
     print("{} schemas were found in the repository.".format(len(records)))
     width = 55
-
+    
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}"
     print(column.format("Title","Filename","Template ID"))
     for r in records:
@@ -442,8 +442,8 @@ def curate(args):
             args['pswd'],
             cert=args['cert'],
             template_title=args['template_name'])
-        print("Successful upload of: {}".format(xml))
-
+        print("Successful upload of:{}".format(xml))
+        
     else:
         print("Performing automatic upload of multiple XML records")
         for xml in args['xml_file']:
@@ -456,8 +456,8 @@ def curate(args):
                 args['pswd'],
                 cert=args['cert'],
                 template_title=args['template_name'])
-
-            print("Successful upload of: {} as {}".format(xml, record_name))
+            
+            print("Successful upload of: {xml} as {record_name}")
 
 # blob rest actions
 def blob(args):
@@ -483,7 +483,7 @@ def explore(args):
                 args['pswd'],
                 cert=args['cert'])
             print("Successful deletion of: {}".format(args['record_id']))
-
+    
     elif any([args['template_name'],args['record_name'],args['record_id']]):
         if not any([args['download_json'],args['download_xml']]):
             records = mdcs.explore.select(
@@ -496,7 +496,7 @@ def explore(args):
                 template=args['template_name'],
                 title=args['record_name'])
             print_xml_records(records)
-
+        
         if args['download_json']:
             records = mdcs.explore.select(
                 args['host'],
@@ -508,7 +508,7 @@ def explore(args):
                 template=args['template_name'],
                 title=args['record_name'])
             write_json_records(records)
-
+        
         if args['download_xml']:
             records = mdcs.explore.select(
                 args['host'],
@@ -529,7 +529,7 @@ def explore(args):
                 cert=args['cert'],
                 format='json')
             print_xml_records(records)
-
+        
         if args['download_json']:
             records = mdcs.explore.select_all(
                 args['host'],
@@ -538,7 +538,7 @@ def explore(args):
                 cert=args['cert'],
                 format='json')
             write_json_records(records)
-
+        
         if args['download_xml']:
             records = mdcs.explore.select_all(
                 args['host'],
@@ -563,7 +563,7 @@ def templates(args):
         print("Success:")
         print("title:"),response['title']
         print("filename:"),response['filename']
-
+    
     elif args['templates_all']:
         templates = mdcs.templates.select_all(
             args['host'],
@@ -574,7 +574,7 @@ def templates(args):
             write_xsd_records(templates)
         else:
             print_xsd_records(templates)
-
+    
     elif args['templates_current']:
         templates = mdcs.templates.select_current(
             args['host'],
@@ -585,7 +585,7 @@ def templates(args):
             write_xsd_records(templates)
         else:
             print_xsd_records(templates)
-
+    
     elif args['templates_find']:
         template_id = mdcs.templates.current_id(
             args['host'],
@@ -594,8 +594,8 @@ def templates(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found {}".format(template_id))
-
+        print("I found"),template_id
+    
     elif args['templates_delete']:
         response = mdcs.templates.delete(
             args['id'],
@@ -605,7 +605,7 @@ def templates(args):
             cert=args['cert'],
             next=args['next'])
         print(response)
-
+    
     elif args['templates_restore']:
         response = mdcs.templates.restore(
             args['id'],
@@ -630,7 +630,7 @@ def types(args):
         print("Success:")
         print("title: {}".format(response['title']))
         print("filename: {}".format(response['filename']))
-
+    
     elif args['types_all']:
         types = mdcs.types.select_all(
             args['host'],
@@ -641,7 +641,7 @@ def types(args):
             write_xsd_records(types)
         else:
             print_xsd_records(types)
-
+    
     elif args['types_current']:
         types = mdcs.types.select_current(
             args['host'],
@@ -652,7 +652,7 @@ def types(args):
             write_xsd_records(types)
         else:
             print_xsd_records(types)
-
+    
     elif args['types_find']:
         type_id = mdcs.types.current_id(
             args['host'],
@@ -661,8 +661,8 @@ def types(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found {}".format(type_id))
-
+        print("I found"),type_id
+    
     elif args['types_delete']:
         response = mdcs.types.delete(
             args['id'],
@@ -672,7 +672,7 @@ def types(args):
             cert=args['cert'],
             next=args['next'])
         print(response)
-
+    
     elif args['types_restore']:
         response = mdcs.types.restore(
             args['id'],
@@ -686,30 +686,30 @@ def types(args):
 def xsd_type_dependencies(xsd_name):
     xsd_type=None
     xsd_dependencies=list()
-
+    
     with open(xsd_name, mode='r') as f:
         xsd_data = f.read()
-
+    
     hash_parser = etree.XMLParser(remove_blank_text=True,remove_comments=True,remove_pis=True)
     etree.set_default_parser(parser=hash_parser)
     xmlTree = etree.parse(BytesIO(xsd_data.encode('utf-8')))
     cleanXmlString = etree.tostring(xmlTree)
     xmlDict = xmltodict.parse(cleanXmlString, dict_constructor=dict)
-
+	
     root_content = xmlDict['xsd:schema'].keys()
-
+    
     if "xsd:element" in root_content or "xs:element" in root_content:
         xsd_type = "template"
     else:
         xsd_type = "type"
-
+    
     root = xmlTree.getroot()
-
+    
     for child in root:
         if "include" in child.tag or "import" in child.tag:
             child_xsd = child.attrib['schemaLocation']
             xsd_dependencies.append(child_xsd)
-
+    
     return xsd_type,xsd_dependencies
 
 def recursive_upload_xsd(xsd_name):
@@ -717,18 +717,18 @@ def recursive_upload_xsd(xsd_name):
     xsd_id=None
     xsd_id_list=list()
     xsd_type,xsd_dependencies = xsd_type_dependencies(xsd_name)
-
+    
     for xsd in xsd_dependencies:
         ref_xsd_id = recursive_upload_xsd(xsd)
-
+        
         xsd_id_list.append(str(ref_xsd_id))
-
+    
     dependencies = str(xsd_id_list)
     dependencies = dependencies.replace(" ","")
     dependencies = dependencies.replace("'","")
     dependencies = dependencies.replace("[","")
     dependencies = dependencies.replace("]","")
-
+    
     if xsd_type is 'type':
         xsd_id = mdcs.types.current_id(
             args['host'],
@@ -754,7 +754,7 @@ def recursive_upload_xsd(xsd_name):
                 title=name)
         else:
             print("found dependency {} as {}".format(name,xsd_id))
-
+            
     else:
         xsd_id = mdcs.templates.current_id(
             args['host'],
@@ -780,7 +780,7 @@ def recursive_upload_xsd(xsd_name):
                 title=name)
         else:
             print("found Template {} as {}".format(name,xsd_id))
-
+    
     return xsd_id
 
 # xsd smart uploader actions

--- a/mdcs-api
+++ b/mdcs-api
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 import argparse
 import getpass
 import mdcs
@@ -52,7 +52,7 @@ def get_function_args():
 
 ''')
     parser.add_argument(
-        '-blob', 
+        '-blob',
         action='store_true',
         dest='blob',
         help=
@@ -75,7 +75,7 @@ def get_function_args():
 
 ''')
     parser.add_argument(
-        '-templates', 
+        '-templates',
         action='store_true',
         dest='templates',
         help=
@@ -94,10 +94,10 @@ def get_function_args():
            -next <ID of template to be promoted to current> [optional]
 -restore   Restore a deleted Template:
            -id <ID of template to restore>
-           
+
 ''')
     parser.add_argument(
-        '-types', 
+        '-types',
         action='store_true',
         dest='types',
         help=
@@ -116,7 +116,7 @@ def get_function_args():
            -next <ID of type to be promoted to current> [optional]
 -restore   Restore a deleted Type:
            -id <ID of type to restore>
-           
+
 ''')
     parser.add_argument(
         '-smart-xsd',
@@ -128,7 +128,7 @@ def get_function_args():
 ''')
     known_args, unknown_args = parser.parse_known_args()
     args = vars(known_args)
-    
+
     # curate command line input
     if args['curate']:
         parser.add_argument(
@@ -147,7 +147,7 @@ def get_function_args():
             dest='record_name',
             default=None,
             type=str)
-    
+
     # blob command line input
     if args['blob']:
         parser.add_argument(
@@ -155,7 +155,7 @@ def get_function_args():
             dest='file',
             type=str,
             required=True)
-    
+
     # explore command line input
     if args['explore']:
         parser.add_argument(
@@ -174,18 +174,18 @@ def get_function_args():
             type=str,
             default=None)
         parser.add_argument(
-            '-j', 
+            '-j',
             action='store_true',
             dest='download_json')
         parser.add_argument(
-            '-x', 
+            '-x',
             action='store_true',
             dest='download_xml')
         parser.add_argument(
-            '-delete', 
+            '-delete',
             action='store_true',
             dest='delete_record')
-    
+
     # templates command line input
     if args['templates']:
         parser.add_argument(
@@ -218,7 +218,7 @@ def get_function_args():
             dest='templates_restore')
         known_args, unknown_args = parser.parse_known_args()
         args = vars(known_args)
-        
+
         if args['templates_add']:
             parser.add_argument(
                 "-x",
@@ -240,14 +240,14 @@ def get_function_args():
                 dest='dependencies',
                 type=str,
                 default=None)
-        
+
         if args['templates_find']:
             parser.add_argument(
                 "-n",
                 dest='name',
                 type=str,
                 required=True)
-        
+
         if args['templates_delete']:
             parser.add_argument(
                 "-id",
@@ -259,47 +259,47 @@ def get_function_args():
                 dest='next',
                 type=str,
                 default=None)
-    
+
         if args['templates_restore']:
             parser.add_argument(
                 "-id",
                 dest='id',
                 type=str,
                 required=True)
-    
+
     # types command line input
     if args['types']:
         parser.add_argument(
-            '-add', 
+            '-add',
             action='store_true',
             dest='types_add')
         parser.add_argument(
-            '-all', 
+            '-all',
             action='store_true',
             dest='types_all')
         parser.add_argument(
-            '-download', 
+            '-download',
             action='store_true',
             dest='download_xsd')
         parser.add_argument(
-            '-current', 
+            '-current',
             action='store_true',
             dest='types_current')
         parser.add_argument(
-            '-find', 
+            '-find',
             action='store_true',
             dest='types_find')
         parser.add_argument(
-            '-delete', 
+            '-delete',
             action='store_true',
             dest='types_delete')
         parser.add_argument(
-            '-restore', 
+            '-restore',
             action='store_true',
             dest='types_restore')
         known_args, unknown_args = parser.parse_known_args()
         args = vars(known_args)
-        
+
         if args['types_add']:
             parser.add_argument(
                 "-x",
@@ -321,14 +321,14 @@ def get_function_args():
                 dest='dependencies',
                 type=str,
                 default=None)
-        
+
         if args['types_find']:
             parser.add_argument(
                 "-n",
                 dest='name',
                 type=str,
                 required=True)
-        
+
         if args['types_delete']:
             parser.add_argument(
                 "-id",
@@ -340,14 +340,14 @@ def get_function_args():
                 dest='next',
                 type=str,
                 default=None)
-        
+
         if args['types_restore']:
             parser.add_argument(
                 "-id",
                 dest='id',
                 type=str,
                 required=True)
-    
+
     # smart-xsd command line input
     if args['smart_xsd']:
         parser.add_argument(
@@ -355,14 +355,14 @@ def get_function_args():
             dest='template_name',
             type=str,
             default=None)
-    
+
     known_args, unknown_args = parser.parse_known_args()
     args = vars(known_args)
-    
+
     # get username and password
     if args['user'] is None: args['user'] = getpass.getuser()
     args['pswd'] = getpass.getpass()
-    
+
     return args
 
 
@@ -394,7 +394,7 @@ def write_xml_records(records):
 def print_xml_records(records):
     print("{} records were found in the repository.".format(len(records)))
     width = 25
-    
+
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}|{3:25}"
     print(column.format("Title","Root Element","Record ID","Template ID"))
     for r in records:
@@ -416,7 +416,7 @@ def write_xsd_records(records):
 def print_xsd_records(records):
     print("{} schemas were found in the repository.".format(len(records)))
     width = 55
-    
+
     column = "{0:"+str(width)+"}|{1:"+str(width)+"}|{2:25}"
     print(column.format("Title","Filename","Template ID"))
     for r in records:
@@ -442,8 +442,8 @@ def curate(args):
             args['pswd'],
             cert=args['cert'],
             template_title=args['template_name'])
-        print("Successful upload of:{}".format(xml))
-        
+        print("Successful upload of: {}".format(xml))
+
     else:
         print("Performing automatic upload of multiple XML records")
         for xml in args['xml_file']:
@@ -456,8 +456,8 @@ def curate(args):
                 args['pswd'],
                 cert=args['cert'],
                 template_title=args['template_name'])
-            
-            print("Successful upload of: {xml} as {record_name}")
+
+            print("Successful upload of: {} as {}".format(xml, record_name))
 
 # blob rest actions
 def blob(args):
@@ -483,7 +483,7 @@ def explore(args):
                 args['pswd'],
                 cert=args['cert'])
             print("Successful deletion of: {}".format(args['record_id']))
-    
+
     elif any([args['template_name'],args['record_name'],args['record_id']]):
         if not any([args['download_json'],args['download_xml']]):
             records = mdcs.explore.select(
@@ -496,7 +496,7 @@ def explore(args):
                 template=args['template_name'],
                 title=args['record_name'])
             print_xml_records(records)
-        
+
         if args['download_json']:
             records = mdcs.explore.select(
                 args['host'],
@@ -508,7 +508,7 @@ def explore(args):
                 template=args['template_name'],
                 title=args['record_name'])
             write_json_records(records)
-        
+
         if args['download_xml']:
             records = mdcs.explore.select(
                 args['host'],
@@ -529,7 +529,7 @@ def explore(args):
                 cert=args['cert'],
                 format='json')
             print_xml_records(records)
-        
+
         if args['download_json']:
             records = mdcs.explore.select_all(
                 args['host'],
@@ -538,7 +538,7 @@ def explore(args):
                 cert=args['cert'],
                 format='json')
             write_json_records(records)
-        
+
         if args['download_xml']:
             records = mdcs.explore.select_all(
                 args['host'],
@@ -563,7 +563,7 @@ def templates(args):
         print("Success:")
         print("title:"),response['title']
         print("filename:"),response['filename']
-    
+
     elif args['templates_all']:
         templates = mdcs.templates.select_all(
             args['host'],
@@ -574,7 +574,7 @@ def templates(args):
             write_xsd_records(templates)
         else:
             print_xsd_records(templates)
-    
+
     elif args['templates_current']:
         templates = mdcs.templates.select_current(
             args['host'],
@@ -585,7 +585,7 @@ def templates(args):
             write_xsd_records(templates)
         else:
             print_xsd_records(templates)
-    
+
     elif args['templates_find']:
         template_id = mdcs.templates.current_id(
             args['host'],
@@ -594,8 +594,8 @@ def templates(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found"),template_id
-    
+        print("I found {}".format(template_id))
+
     elif args['templates_delete']:
         response = mdcs.templates.delete(
             args['id'],
@@ -605,7 +605,7 @@ def templates(args):
             cert=args['cert'],
             next=args['next'])
         print(response)
-    
+
     elif args['templates_restore']:
         response = mdcs.templates.restore(
             args['id'],
@@ -630,7 +630,7 @@ def types(args):
         print("Success:")
         print("title: {}".format(response['title']))
         print("filename: {}".format(response['filename']))
-    
+
     elif args['types_all']:
         types = mdcs.types.select_all(
             args['host'],
@@ -641,7 +641,7 @@ def types(args):
             write_xsd_records(types)
         else:
             print_xsd_records(types)
-    
+
     elif args['types_current']:
         types = mdcs.types.select_current(
             args['host'],
@@ -652,7 +652,7 @@ def types(args):
             write_xsd_records(types)
         else:
             print_xsd_records(types)
-    
+
     elif args['types_find']:
         type_id = mdcs.types.current_id(
             args['host'],
@@ -661,8 +661,8 @@ def types(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found"),type_id
-    
+        print("I found {}".format(type_id))
+
     elif args['types_delete']:
         response = mdcs.types.delete(
             args['id'],
@@ -672,7 +672,7 @@ def types(args):
             cert=args['cert'],
             next=args['next'])
         print(response)
-    
+
     elif args['types_restore']:
         response = mdcs.types.restore(
             args['id'],
@@ -686,30 +686,30 @@ def types(args):
 def xsd_type_dependencies(xsd_name):
     xsd_type=None
     xsd_dependencies=list()
-    
+
     with open(xsd_name, mode='r') as f:
         xsd_data = f.read()
-    
+
     hash_parser = etree.XMLParser(remove_blank_text=True,remove_comments=True,remove_pis=True)
     etree.set_default_parser(parser=hash_parser)
     xmlTree = etree.parse(BytesIO(xsd_data.encode('utf-8')))
     cleanXmlString = etree.tostring(xmlTree)
     xmlDict = xmltodict.parse(cleanXmlString, dict_constructor=dict)
-	
+
     root_content = xmlDict['xsd:schema'].keys()
-    
+
     if "xsd:element" in root_content or "xs:element" in root_content:
         xsd_type = "template"
     else:
         xsd_type = "type"
-    
+
     root = xmlTree.getroot()
-    
+
     for child in root:
         if "include" in child.tag or "import" in child.tag:
             child_xsd = child.attrib['schemaLocation']
             xsd_dependencies.append(child_xsd)
-    
+
     return xsd_type,xsd_dependencies
 
 def recursive_upload_xsd(xsd_name):
@@ -717,18 +717,18 @@ def recursive_upload_xsd(xsd_name):
     xsd_id=None
     xsd_id_list=list()
     xsd_type,xsd_dependencies = xsd_type_dependencies(xsd_name)
-    
+
     for xsd in xsd_dependencies:
         ref_xsd_id = recursive_upload_xsd(xsd)
-        
+
         xsd_id_list.append(str(ref_xsd_id))
-    
+
     dependencies = str(xsd_id_list)
     dependencies = dependencies.replace(" ","")
     dependencies = dependencies.replace("'","")
     dependencies = dependencies.replace("[","")
     dependencies = dependencies.replace("]","")
-    
+
     if xsd_type is 'type':
         xsd_id = mdcs.types.current_id(
             args['host'],
@@ -754,7 +754,7 @@ def recursive_upload_xsd(xsd_name):
                 title=name)
         else:
             print("found dependency {} as {}".format(name,xsd_id))
-            
+
     else:
         xsd_id = mdcs.templates.current_id(
             args['host'],
@@ -780,7 +780,7 @@ def recursive_upload_xsd(xsd_name):
                 title=name)
         else:
             print("found Template {} as {}".format(name,xsd_id))
-    
+
     return xsd_id
 
 # xsd smart uploader actions

--- a/mdcs-api
+++ b/mdcs-api
@@ -457,7 +457,7 @@ def curate(args):
                 cert=args['cert'],
                 template_title=args['template_name'])
             
-            print("Successful upload of: {xml} as {record_name}")
+            print("Successful upload of: {} as {}".format(xml, record_name))
 
 # blob rest actions
 def blob(args):
@@ -594,7 +594,7 @@ def templates(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found"),template_id
+        print("I found {}".format(template_id))
     
     elif args['templates_delete']:
         response = mdcs.templates.delete(
@@ -661,7 +661,7 @@ def types(args):
             cert=args['cert'],
             filename=args['name'],
             title=args['name'])
-        print("I found"),type_id
+        print("I found {}".format(type_id))
     
     elif args['types_delete']:
         response = mdcs.types.delete(

--- a/mdcs/__init__.py
+++ b/mdcs/__init__.py
@@ -1,13 +1,12 @@
-import blob
-from curate import curate
-from curate import curate_as
-import explore
-import exporter
-import repository
-import saved_queries
-import templates
-import types
-import users
 import requests
-import utils
+from .blob import *
+from .curate import *
+from .explore import *
+from .exporter import *
+from .repository import *
+from .saved_queries import *
+from .templates import *
+from .types import *
+from .users import *
+from .utils import *
 requests.packages.urllib3.disable_warnings()

--- a/mdcs/blob.py
+++ b/mdcs/blob.py
@@ -1,6 +1,5 @@
-#! /usr/bin/env python
 import requests
-from utils import check_response
+from .utils import check_response
 
 def upload(name,host,user,pswd,cert=None):
     url = host.strip("/") + "/rest/blob"

--- a/mdcs/curate.py
+++ b/mdcs/curate.py
@@ -1,21 +1,23 @@
-#! /usr/bin/env python
 import requests
-from templates import current_id
-from utils import check_response
+from .templates import current_id
+from .utils import check_response
 
-def curate(file_name,file_title,template_id,host,user,pswd,cert=None,content=None):
+
+def curate(file_name, file_title, template_id, host, user, pswd, cert=None, content=None):
     if content is None:
-        with open(file_name, 'r') as f: 
+        with open(file_name, 'r') as f:
             content = f.read()
-    data=dict()
-    data['content']=[content]
-    data['schema']=[template_id]
-    data['title']=[file_title]
-    
-    url = host.strip("/") +  "/rest/curate"
+    data = dict()
+    data['content'] = [content]
+    data['schema'] = [template_id]
+    data['title'] = [file_title]
+
+    url = host.strip("/") + "/rest/curate"
     r = requests.post(url, data=data, auth=(user, pswd), verify=cert)
     return check_response(r)
 
-def curate_as(file_name,file_title,host,user,pswd,cert=None,filename=None,template_title=None,content=None):
-    template_id = current_id(host,user,pswd,cert=cert,filename=filename,title=template_title)
-    return curate(file_name,file_title,template_id,host,user,pswd,cert=cert,content=content)
+
+def curate_as(file_name, file_title, host, user, pswd, cert=None, filename=None, template_title=None, content=None):
+    template_id = current_id(host, user, pswd, cert=cert,
+                             filename=filename, title=template_title)
+    return curate(file_name, file_title, template_id, host, user, pswd, cert=cert, content=content)

--- a/mdcs/explore.py
+++ b/mdcs/explore.py
@@ -1,11 +1,11 @@
-#! /usr/bin/env python
 import requests
 from collections import OrderedDict
-from utils import check_response
+from .utils import check_response
 
-def select_all(host,user,pswd,cert=None,format=None):
+
+def select_all(host, user, pswd, cert=None, format=None):
     """Get all data from the MDCS server
-    
+
     Inputs:
         host - string, URL of MDCS instance
         user - string, username of desired account on MDCS server
@@ -22,13 +22,15 @@ def select_all(host,user,pswd,cert=None,format=None):
     """
     url = host.strip("/") + "/rest/explore/select/all"
     params = dict()
-    if format: params['dataformat'] = format
+    if format:
+        params['dataformat'] = format
     r = requests.get(url, params=params, auth=(user, pswd), verify=cert)
     return check_response(r)
 
-def select(host,user,pswd,cert=None,format=None,ID=None,template=None,title=None):
+
+def select(host, user, pswd, cert=None, format=None, ID=None, template=None, title=None):
     """Get all data that fits a certain simple query
-    
+
     Inputs:
         host - string, URL of MDCS instance
         user - string, username of desired account on MDCS server
@@ -48,16 +50,21 @@ def select(host,user,pswd,cert=None,format=None,ID=None,template=None,title=None
     """
     url = host.strip("/") + "/rest/explore/select"
     params = dict()
-    if format:   params['dataformat'] = format
-    if ID:       params['id']         = ID
-    if template: params['schema']     = template
-    if title:    params['title']      = title
+    if format:
+        params['dataformat'] = format
+    if ID:
+        params['id'] = ID
+    if template:
+        params['schema'] = template
+    if title:
+        params['title'] = title
     r = requests.get(url, params=params, auth=(user, pswd), verify=cert)
     return check_response(r)
-    
-def delete(ID,host,user,pswd,cert=None):
+
+
+def delete(ID, host, user, pswd, cert=None):
     """Delete an entry
-    
+
     Input:
         ID - string, ID of object to be deleted
         host - string, URL of MDCS instance
@@ -67,16 +74,17 @@ def delete(ID,host,user,pswd,cert=None):
     Output:
         response from MDCS
     """
-    
+
     url = host.strip("/") + "/rest/explore/delete"
     params = dict()
-    params['id']=ID
+    params['id'] = ID
     r = requests.delete(url, params=params, auth=(user, pswd), verify=cert)
     return check_response(r)
-    
-def query(host,user,pswd,cert=None,format=None,query=None,repositories=None):
+
+
+def query(host, user, pswd, cert=None, format=None, query=None, repositories=None):
     """Query by example.
-    
+
     Input:
         host - string, URL of MDCS instance
         user - string, username of desired account on MDCS server
@@ -94,8 +102,11 @@ def query(host,user,pswd,cert=None,format=None,query=None,repositories=None):
     """
     url = host.strip("/") + "/rest/explore/query-by-example"
     data = dict()
-    if format: data['dataformat'] = format
-    if query: data['query'] = query
-    if repositories: data['repositories'] = repositories
+    if format:
+        data['dataformat'] = format
+    if query:
+        data['query'] = query
+    if repositories:
+        data['repositories'] = repositories
     r = requests.post(url, data=data, auth=(user, pswd), verify=cert)
     return check_response(r)

--- a/mdcs/exporter.py
+++ b/mdcs/exporter.py
@@ -1,1 +1,0 @@
-#! /usr/bin/env python

--- a/mdcs/repository.py
+++ b/mdcs/repository.py
@@ -1,1 +1,0 @@
-#! /usr/bin/env python

--- a/mdcs/saved_queries.py
+++ b/mdcs/saved_queries.py
@@ -1,1 +1,1 @@
-#! /usr/bin/env python
+#

--- a/mdcs/templates.py
+++ b/mdcs/templates.py
@@ -1,6 +1,5 @@
-#! /usr/bin/env python
 import requests
-from utils import check_response
+from .utils import check_response
 
 def add(filename,title,host,user,pswd,cert=None,version=None,dependencies=None):
     url = host.strip("/") + "/rest/templates/add"

--- a/mdcs/types.py
+++ b/mdcs/types.py
@@ -1,6 +1,5 @@
-#! /usr/bin/env python
 import requests
-from utils import check_response
+from .utils import check_response
 
 def add(filename,title,host,user,pswd,cert=None,version=None,dependencies=None):
     url = host.strip("/") + "/rest/types/add"

--- a/mdcs/users.py
+++ b/mdcs/users.py
@@ -1,1 +1,0 @@
-#! /usr/bin/env python

--- a/mdcs/utils.py
+++ b/mdcs/utils.py
@@ -1,6 +1,6 @@
-#! /usr/bin/env python
 from collections import OrderedDict
 import sys
+
 
 def check_response(r):
     try:
@@ -8,8 +8,8 @@ def check_response(r):
     except:
         r_content = r.text
     if str(r.status_code)[0] is not "2":
-        print "Error: ",r.status_code
-        print r.text
+        print("Error: {}".format(r.status_code))
+        print(r.text)
         sys.exit(0)
     else:
         return r_content

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     license=license,
     install_requires=[
         'requests',
+        'lxml',
         'xmltodict',
     ],
     packages=find_packages(exclude=('tests', 'docs'))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license=license,
     install_requires=[
         'requests',
-        'lxml',
         'xmltodict',
     ],
     packages=find_packages(exclude=('tests', 'docs'))


### PR DESCRIPTION
- change `print "*", ` to `print("* {}".format())`
- change import method in `mdcs/__init__.py`
- ignore python3 temp dirs for git
- add lxml to requires
- remove all shebang snippets of `*.py` in mdcs folder
- adapt all `*.py` files to PEP8 style, except mdcs-api script(too much modification for a clear merge)

Only tested lightly in python 3.6.1, maybe it need a new branch for further testing, especially with python2.